### PR TITLE
feat:Allow custom instructions, handle comments

### DIFF
--- a/.github/workflows/dry_run.yml
+++ b/.github/workflows/dry_run.yml
@@ -2,7 +2,9 @@ name: Pull Request Text Generator Workflow
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, edited, reopened]
+  issue_comment:
+    types: [created]
 
 jobs:
   generate-pr-text:
@@ -11,7 +13,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Run auto-pr-writer action
+      - name: Run for PR
+        if: github.event_name == 'pull_request'
         uses: ./
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          instruction: ${{ github.event.pull_request.body }}
+      - name: Run for comment
+        if: github.event_name == 'issue_comment' && github.event.issue.pull_request
+        uses: ./
+        with:
+          openai_api_key: ${{ secrets.OPENAI_API_KEY }}
+          instruction: ${{ github.event.comment.body }}


### PR DESCRIPTION
Given the content of the provided JSON, assuming that the contextual instruction is to take that phrase into account for the PR description, here is an example of a PR text:

### Why
The latest changes aim at enhancing the GitHub Actions workflow by allowing the Pull Request Text Generator Workflow to trigger not only on PR open events but also when PRs are edited, reopened, or when comments are made on the PRs. This ensures that the automated generation of PR text reflects the latest discussions and changes.

### What
The `.github/workflows/dry_run.yml` file has been modified to listen for more GitHub event types. Specifically, the workflow now reacts to `edited`, `reopened`, and `created` event types for PRs and issue comments.

### How can it be used
With these changes, users can experience a more interactive and responsive workflow. Subsequent updates to PR descriptions or discussions in PR comments can invoke the auto-pr-writer action, ensuring that the latest information is considered while auto-generating PR texts.

### How did you test it
The testing for this feature should include:

1. Opening a PR to ensure the action is triggered.
2. Editing the PR to check if updates invoke the action.
3. Closing and reopening the PR to validate action re-triggering.
4. Posting a comment in the PR to verify that the action processes the comment.

Each of these steps should lead to the action executing, which can be confirmed by checking the outputs in the Action tabs of the PR.

### Notes for the reviewer
Ensure to review the YAML syntax and confirm that the action hooks for events are correctly set up. Also, check if the conditional execution paths (`if: github.event_name == 'pull_request'` and `if: github.event_name == 'issue_comment' && github.event.issue.pull_request`) are correctly capturing the contexts for PR actions and issue comments. The injected instructions via `${{ github.event.pull_request.body }}` and `${{ github.event.comment.body }}` should also be verified.