### PR TITLE
Add default openai_base_url

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,7 @@ inputs:
   openai_base_url:
     description: OpenAI Base URL
     required: false
+    default: https://api.openai.com/v1
   github_token:
     description: GITHUB_TOKEN or a repo scoped PAT
     default: ${{ github.token }}


### PR DESCRIPTION
### Why
The update introduces a default OpenAI base URL to the `action.yml` configuration file. This is important as it ensures that there's a standard reference point for API requests, reducing potential errors due to missing or incorrect base URLs provided by users.

### What
A single line was added to `action.yml` setting the default value of `openai_base_url` to `https://api.openai.com/v1`. This change enables the action to operate with a predefined base URL without requiring user input unless a different endpoint is needed.

### How can it be used
The action now has a default OpenAI base URL, meaning users do not need to specify this URL when configuring the action, simplifying the setup process. Users who wish to target a different OpenAI API endpoint can still do so by providing their own URL during configuration.

### How did you test it
As the changes are configuration-based and straightforward, a manual verification of the `action.yml` file to ensure the default URL is correctly set would be sufficient. Functional testing would involve running the action in a controlled environment to confirm it communicates with the OpenAI endpoint using the newly set default URL.

### Notes for the reviewer
While reviewing the proposed changes, please check if the URL is correctly formatted and matches the standard endpoint provided by OpenAI. No additional code changes are present, and the action's functionality remains the same barring this default configuration alteration.