### PR TITLE
Rename action inputs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Automatic PR Text Generation
 🚀 An auto-generated PR description will appear shortly after opening the PR. Feel free to modify it as needed.
 
-📝 Guide the automated process by giving instructions to @auto-pr-writer-bot in your description or comments.
+📝 Guide the automated process by giving instructions to @auto-pr-writer-bot
 
 👍 Go ahead and click "Create pull request". The tailored PR description will be ready soon!

--- a/.github/workflows/pr-text-generator.yml
+++ b/.github/workflows/pr-text-generator.yml
@@ -18,7 +18,7 @@ jobs:
         uses: ./
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          instruction: ${{ github.event.pull_request.body }}
+          user_prompt: ${{ github.event.pull_request.body }}
       - name: Debug PR Number
         if: github.event_name == 'issue_comment' && github.event.issue.pull_request
         run: echo ${{ github.event.issue.number }}
@@ -35,7 +35,7 @@ jobs:
         uses: ./
         with:
           openai_api_key: ${{ secrets.OPENAI_API_KEY }}
-          instruction: ${{ github.event.comment.body }}
+          user_prompt: ${{ github.event.comment.body }}
           target_branch: ${{ fromJson(steps.pr_details.outputs.data).base.ref }}
           source_branch: ${{ fromJson(steps.pr_details.outputs.data).head.ref }}
           pull_request_number: ${{ github.event.issue.number }}

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ The source branch in the pull request. Defaults to the head branch of the curren
 **Optional**
 The generation_model specifies the model to use for PR text generation. While it defaults to gpt-4-1106-preview from OpenAI, users have the flexibility to select from a range of models available from various LLM providers, including but not limited to fireworks.ai, together.xyz, anyscale, octoai, etc. This allows for more tailored and varied text generation capabilities to meet diverse needs and preferences.
 
-#### `system`
+#### `system_prompt`
 **Optional**
 System message/prompt to help the model generate the PR description.
 
-#### `instruction`
+#### `user_prompt`
 **Optional**
-Additional prompt to help the model generate the PR description.
+Additional user prompt to help the model generate the PR description.
 
 
 ## Contributing

--- a/action.yml
+++ b/action.yml
@@ -30,10 +30,10 @@ inputs:
   generation_model:
     description: LLM to use for PR text generation
     default: gpt-4-1106-preview
-  system:
+  system_prompt:
     description: System message/prompt to help the model generate the PR description
     required: false
-  instruction:
+  user_prompt:
     description: Additional prompt to help the model generate the PR description
     required: false
 runs:
@@ -48,5 +48,5 @@ runs:
     BASE_REF: ${{ inputs.target_branch }}
     HEAD_REF: ${{ inputs.source_branch }}
     GENERATION_MODEL: ${{ inputs.generation_model }}
-    AUTO_PR_WRITER_SYSTEM_MESSAGE: ${{ inputs.system }}
-    AUTO_PR_WRITER_USER_MESSAGE: ${{ inputs.instruction }}
+    AUTO_PR_WRITER_SYSTEM_MESSAGE: ${{ inputs.system_prompt }}
+    AUTO_PR_WRITER_USER_MESSAGE: ${{ inputs.user_prompt }}


### PR DESCRIPTION
### Why

The purpose of this pull request is to rename various input fields within the action configuration and documentation, thereby providing better clarity on their usage and enhancing the interaction with the auto PR writer bot.

### What

The changes introduced by this PR involve renaming several input parameters within the repository:

1. In the action configuration (`action.yml`), `system` has been renamed to `system_prompt`, and `instruction` has been renamed to `user_prompt`.
2. In the PR text generator workflow (`pr-text-generator.yml`), the `instruction` field (presumably used as an action input) is updated to the new `user_prompt`.
3. The default PR template (`pull_request_template.md`) is modified to simplify the guidance for using the auto PR writer bot.
4. The `README.md` file is updated to reflect these name changes in the documentation, ensuring that users reference the correct input names.

### How can it be used

Users of the auto PR writer bot should now use the new input names `system_prompt` and `user_prompt` when configuring the bot in their GitHub Actions workflow. These clearer names will aid users in providing the necessary prompts to guide the bot in generating appropriate PR descriptions.

### How did you test it

To test these changes, you would typically configure a GitHub Actions workflow with the updated input names and observe if the auto PR writer bot behaves as expected, generating a PR description according to the new prompts.

### Notes for the reviewer

Since these changes are mostly renames and updates to documentation, thorough testing might not be critical but verifying that the action's configuration matches the documentation, and that no instances of the old input names remain, should be sufficient.