### PR TITLE
Custom bot name

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Additional user prompt to help the model generate the PR description.
 **Optional**
 The name of the GitHub event that triggered the workflow. Useful for the underlying Python script to determine whether the action is run on a pull request or an issue comment event. Defaults to github.event_name variable.
 
+#### `bot_name`
+**Optional**
+The name of the bot so users can guide LLM generation with @bot_name from PR comments. Defaults to auto-pr-writer-bot
+
 ## Contributing
 
 If you have suggestions for improving Auto PR Writer or want to report a bug, please feel welcome to open an issue or a pull request. Here are some guidelines to help you contribute effectively:

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,9 @@ inputs:
   event_name:
     description: The name of the GitHub event that triggered the workflow
     default: ${{ github.event_name }}
+  bot_name:
+    description: The name of the bot so users can guide LLM generation with @bot_name from PR comments
+    default: auto-pr-writer-bot
 runs:
   using: 'docker'
   image: 'docker://vblagoje/auto-pr-writer:latest'
@@ -54,3 +57,4 @@ runs:
     AUTO_PR_WRITER_SYSTEM_MESSAGE: ${{ inputs.system_prompt }}
     AUTO_PR_WRITER_USER_MESSAGE: ${{ inputs.user_prompt }}
     EVENT_NAME: ${{ inputs.event_name }}
+    AUTO_PR_WRITER_BOT_NAME: ${{ inputs.bot_name }}


### PR DESCRIPTION
# Why:

This pull request aims to enhance user experience and customization for Auto PR Writer. The primary motivation is to provide users with the flexibility to define a bot name for easier user instruction handling, improving the overall interactivity and guidance during PR generation.

# What:

* Introduced the `bot_name` input for the action, enabling users to specify their preferred bot name.
* Updated the bot name in the `README.md` and `action.yml` files to reflect this change.
* Modified the `auto_pr_writer.py` file to fetch the bot name from the environment variables with a default value.
* Adjusted regex patterns in the `extract_custom_instruction` function to accommodate custom instructions following the '@' mention of the bot name.

# How can it be used:

Users can now specify a custom bot name in the action inputs by setting the `bot_name` input to their desired name. This change allows for more personalized interaction and instruction guidance in PR comments.

# How did you test it:

The changes were tested by locally executing the action with a custom bot name. The regex patterns were tested with sample user instructions containing the bot name. No unit tests were added as part of this pull request, but the existing functionality was verified to work as expected.

# Notes for the reviewer:

Please pay attention to the modifications in `action.yml` and `auto_pr_writer.py`, ensuring that the action correctly parses the `bot_name` input and uses the specified name. Additionally, confirm that the regex patterns correctly extract custom instructions following the bot name mention.</s>