### PR TITLE
Load github spec locally

### DIFF
--- a/auto_pr_writer.py
+++ b/auto_pr_writer.py
@@ -18,6 +18,10 @@ def read_system_message() -> str:
     return os.environ.get("AUTO_PR_WRITER_SYSTEM_MESSAGE") or open("system_prompt.txt").read()
 
 
+def load_github_compare_service_spec() -> Dict[str, Any]:
+    return json.loads(open("github_compare_spec.json").read())
+
+
 def generate_pr_text(
     github_repo: str, base_branch: str, pr_branch: str, model_name: str, custom_instruction: Optional[str] = None
 ) -> str:
@@ -40,8 +44,8 @@ def generate_pr_text(
     :rtype: str
     :raises ValueError: If the OPENAI_API_KEY environment variable is not set.
     """
-    # fetch the OpenAPI specification of the GitHub compare service
-    openapi_spec = requests.get("https://bit.ly/3tJbUpZ").json()
+    # read the OpenAPI specification of the GitHub compare service
+    openapi_spec = load_github_compare_service_spec()
 
     # a GitHub access token is required to invoke the GitHub compare service and avoid rate limiting
     service_auth = {"Github API": os.environ.get("GITHUB_TOKEN")}

--- a/github_compare_spec.json
+++ b/github_compare_spec.json
@@ -1,0 +1,562 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Github API",
+        "description": "Enables interaction with OpenAPI",
+        "version": "v1.0.0"
+    },
+    "servers": [
+        {
+            "url": "https://api.github.com"
+        }
+    ],
+    "paths": {
+        "/repos/{owner}/{repo}/compare/{basehead}": {
+            "get": {
+                "summary": "Compare two branches",
+                "description": "Compares two branches against one another.",
+                "tags": [
+                    "repos"
+                ],
+                "operationId": "compare_branches",
+                "externalDocs": {
+                    "description": "API method documentation",
+                    "url": "https://docs.github.com/enterprise-server@3.9/rest/commits/commits#compare-two-commits"
+                },
+                "parameters": [
+                    {
+                        "name": "basehead",
+                        "description": "The base branch and head branch to compare. This parameter expects the format `BASE...HEAD`",
+                        "in": "path",
+                        "required": true,
+                        "x-multi-segment": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "owner",
+                        "description": "The repository owner, usually a company or orgnization",
+                        "in": "path",
+                        "required": true,
+                        "x-multi-segment": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "repo",
+                        "description": "The repository itself, the project",
+                        "in": "path",
+                        "required": true,
+                        "x-multi-segment": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Response",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/commit-comparison"
+                                }
+                            }
+                        }
+                    }
+                },
+                "x-github": {
+                    "githubCloudOnly": false,
+                    "enabledForGitHubApps": true,
+                    "category": "commits",
+                    "subcategory": "commits"
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "commit-comparison": {
+                "title": "Commit Comparison",
+                "description": "Commit Comparison",
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/repos/octocat/Hello-World/compare/master...topic"
+                    },
+                    "html_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/compare/master...topic"
+                    },
+                    "permalink_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/compare/octocat:bbcd538c8e72b8c175046e27cc8f907076331401...octocat:0328041d1152db8ae77652d1618a02e57f745f17"
+                    },
+                    "diff_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/compare/master...topic.diff"
+                    },
+                    "patch_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/compare/master...topic.patch"
+                    },
+                    "base_commit": {
+                        "$ref": "#/components/schemas/commit"
+                    },
+                    "merge_base_commit": {
+                        "$ref": "#/components/schemas/commit"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "diverged",
+                            "ahead",
+                            "behind",
+                            "identical"
+                        ],
+                        "example": "ahead"
+                    },
+                    "ahead_by": {
+                        "type": "integer",
+                        "example": 4
+                    },
+                    "behind_by": {
+                        "type": "integer",
+                        "example": 5
+                    },
+                    "total_commits": {
+                        "type": "integer",
+                        "example": 6
+                    },
+                    "commits": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/commit"
+                        }
+                    },
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/diff-entry"
+                        }
+                    }
+                },
+                "required": [
+                    "url",
+                    "html_url",
+                    "permalink_url",
+                    "diff_url",
+                    "patch_url",
+                    "base_commit",
+                    "merge_base_commit",
+                    "status",
+                    "ahead_by",
+                    "behind_by",
+                    "total_commits",
+                    "commits"
+                ]
+            },
+            "nullable-git-user": {
+                "title": "Git User",
+                "description": "Metaproperties for Git author/committer information.",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "example": "\"Chris Wanstrath\""
+                    },
+                    "email": {
+                        "type": "string",
+                        "example": "\"chris@ozmm.org\""
+                    },
+                    "date": {
+                        "type": "string",
+                        "example": "\"2007-10-29T02:42:39.000-07:00\""
+                    }
+                },
+                "nullable": true
+            },
+            "nullable-simple-user": {
+                "title": "Simple User",
+                "description": "A GitHub user.",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    "email": {
+                        "nullable": true,
+                        "type": "string"
+                    },
+                    "login": {
+                        "type": "string",
+                        "example": "octocat"
+                    },
+                    "id": {
+                        "type": "integer",
+                        "example": 1
+                    },
+                    "node_id": {
+                        "type": "string",
+                        "example": "MDQ6VXNlcjE="
+                    },
+                    "avatar_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/images/error/octocat_happy.gif"
+                    },
+                    "gravatar_id": {
+                        "type": "string",
+                        "example": "41d064eb2195891e12d0413f63227ea7",
+                        "nullable": true
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat"
+                    },
+                    "html_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat"
+                    },
+                    "followers_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat/followers"
+                    },
+                    "following_url": {
+                        "type": "string",
+                        "example": "https://api.github.com/users/octocat/following{/other_user}"
+                    },
+                    "gists_url": {
+                        "type": "string",
+                        "example": "https://api.github.com/users/octocat/gists{/gist_id}"
+                    },
+                    "starred_url": {
+                        "type": "string",
+                        "example": "https://api.github.com/users/octocat/starred{/owner}{/repo}"
+                    },
+                    "subscriptions_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat/subscriptions"
+                    },
+                    "organizations_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat/orgs"
+                    },
+                    "repos_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat/repos"
+                    },
+                    "events_url": {
+                        "type": "string",
+                        "example": "https://api.github.com/users/octocat/events{/privacy}"
+                    },
+                    "received_events_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/users/octocat/received_events"
+                    },
+                    "type": {
+                        "type": "string",
+                        "example": "User"
+                    },
+                    "site_admin": {
+                        "type": "boolean"
+                    },
+                    "starred_at": {
+                        "type": "string",
+                        "example": "\"2020-07-09T00:17:55Z\""
+                    }
+                },
+                "required": [
+                    "avatar_url",
+                    "events_url",
+                    "followers_url",
+                    "following_url",
+                    "gists_url",
+                    "gravatar_id",
+                    "html_url",
+                    "id",
+                    "node_id",
+                    "login",
+                    "organizations_url",
+                    "received_events_url",
+                    "repos_url",
+                    "site_admin",
+                    "starred_url",
+                    "subscriptions_url",
+                    "type",
+                    "url"
+                ],
+                "nullable": true
+            },
+            "verification": {
+                "title": "Verification",
+                "type": "object",
+                "properties": {
+                    "verified": {
+                        "type": "boolean"
+                    },
+                    "reason": {
+                        "type": "string"
+                    },
+                    "payload": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "signature": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "verified",
+                    "reason",
+                    "payload",
+                    "signature"
+                ]
+            },
+            "diff-entry": {
+                "title": "Diff Entry",
+                "description": "Diff Entry",
+                "type": "object",
+                "properties": {
+                    "sha": {
+                        "type": "string",
+                        "example": "bbcd538c8e72b8c175046e27cc8f907076331401"
+                    },
+                    "filename": {
+                        "type": "string",
+                        "example": "file1.txt"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "added",
+                            "removed",
+                            "modified",
+                            "renamed",
+                            "copied",
+                            "changed",
+                            "unchanged"
+                        ],
+                        "example": "added"
+                    },
+                    "additions": {
+                        "type": "integer",
+                        "example": 103
+                    },
+                    "deletions": {
+                        "type": "integer",
+                        "example": 21
+                    },
+                    "changes": {
+                        "type": "integer",
+                        "example": 124
+                    },
+                    "blob_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/blob/6dcb09b5b57875f334f61aebed695e2e4193db5e/file1.txt"
+                    },
+                    "raw_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/raw/6dcb09b5b57875f334f61aebed695e2e4193db5e/file1.txt"
+                    },
+                    "contents_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/repos/octocat/Hello-World/contents/file1.txt?ref=6dcb09b5b57875f334f61aebed695e2e4193db5e"
+                    },
+                    "patch": {
+                        "type": "string",
+                        "example": "@@ -132,7 +132,7 @@ module Test @@ -1000,7 +1000,7 @@ module Test"
+                    },
+                    "previous_filename": {
+                        "type": "string",
+                        "example": "file.txt"
+                    }
+                },
+                "required": [
+                    "additions",
+                    "blob_url",
+                    "changes",
+                    "contents_url",
+                    "deletions",
+                    "filename",
+                    "raw_url",
+                    "sha",
+                    "status"
+                ]
+            },
+            "commit": {
+                "title": "Commit",
+                "description": "Commit",
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+                    },
+                    "sha": {
+                        "type": "string",
+                        "example": "6dcb09b5b57875f334f61aebed695e2e4193db5e"
+                    },
+                    "node_id": {
+                        "type": "string",
+                        "example": "MDY6Q29tbWl0NmRjYjA5YjViNTc4NzVmMzM0ZjYxYWViZWQ2OTVlMmU0MTkzZGI1ZQ=="
+                    },
+                    "html_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://github.com/octocat/Hello-World/commit/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+                    },
+                    "comments_url": {
+                        "type": "string",
+                        "format": "uri",
+                        "example": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e/comments"
+                    },
+                    "commit": {
+                        "type": "object",
+                        "properties": {
+                            "url": {
+                                "type": "string",
+                                "format": "uri",
+                                "example": "https://api.github.com/repos/octocat/Hello-World/commits/6dcb09b5b57875f334f61aebed695e2e4193db5e"
+                            },
+                            "author": {
+                                "$ref": "#/components/schemas/nullable-git-user"
+                            },
+                            "committer": {
+                                "$ref": "#/components/schemas/nullable-git-user"
+                            },
+                            "message": {
+                                "type": "string",
+                                "example": "Fix all the bugs"
+                            },
+                            "comment_count": {
+                                "type": "integer",
+                                "example": 0
+                            },
+                            "tree": {
+                                "type": "object",
+                                "properties": {
+                                    "sha": {
+                                        "type": "string",
+                                        "example": "827efc6d56897b048c772eb4087f854f46256132"
+                                    },
+                                    "url": {
+                                        "type": "string",
+                                        "format": "uri",
+                                        "example": "https://api.github.com/repos/octocat/Hello-World/tree/827efc6d56897b048c772eb4087f854f46256132"
+                                    }
+                                },
+                                "required": [
+                                    "sha",
+                                    "url"
+                                ]
+                            },
+                            "verification": {
+                                "$ref": "#/components/schemas/verification"
+                            }
+                        },
+                        "required": [
+                            "author",
+                            "committer",
+                            "comment_count",
+                            "message",
+                            "tree",
+                            "url"
+                        ]
+                    },
+                    "author": {
+                        "$ref": "#/components/schemas/nullable-simple-user"
+                    },
+                    "committer": {
+                        "$ref": "#/components/schemas/nullable-simple-user"
+                    },
+                    "parents": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "sha": {
+                                    "type": "string",
+                                    "example": "7638417db6d59f3c431d3e1f261cc637155684cd"
+                                },
+                                "url": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "example": "https://api.github.com/repos/octocat/Hello-World/commits/7638417db6d59f3c431d3e1f261cc637155684cd"
+                                },
+                                "html_url": {
+                                    "type": "string",
+                                    "format": "uri",
+                                    "example": "https://github.com/octocat/Hello-World/commit/7638417db6d59f3c431d3e1f261cc637155684cd"
+                                }
+                            },
+                            "required": [
+                                "sha",
+                                "url"
+                            ]
+                        }
+                    },
+                    "stats": {
+                        "type": "object",
+                        "properties": {
+                            "additions": {
+                                "type": "integer"
+                            },
+                            "deletions": {
+                                "type": "integer"
+                            },
+                            "total": {
+                                "type": "integer"
+                            }
+                        }
+                    },
+                    "files": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/diff-entry"
+                        }
+                    }
+                },
+                "required": [
+                    "url",
+                    "sha",
+                    "node_id",
+                    "html_url",
+                    "comments_url",
+                    "commit",
+                    "author",
+                    "committer",
+                    "parents"
+                ]
+            }
+        },
+        "securitySchemes": {
+            "apikey": {
+                "type": "apiKey",
+                "name": "x-api-key",
+                "in": "header"
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Why:
This pull request enhances the functionality of the Auto PR Writer by introducing the capability to load GitHub Comparative Service Specs locally. The motivation behind this is to reduce network requests and enable the use of the OpenAPI specification of this service for a more efficient and user-customizable experience.

### What:

* Added a `load_github_compare_service_spec()` function to load the GitHub Comparative Service Specs locally from a JSON file.
* Modified the `generate_pr_text()` function to use the locally loaded OpenAPI specification.
* Added a `github_compare_spec.json` file containing the OpenAPI specification of the GitHub compare service.

### How can it be used:
By using the modified Auto PR Writer, users can now reduce network requests and enhance their experience with the tool. They can make the necessary changes to the `github_compare_spec.json` file to customize the behavior according to their requirements.

### How did you test it:
To test this change, I ensured that the `generate_pr_text()` function still worked as intended while using the locally loaded OpenAPI specification. I also verified that the new `load_github_compare_service_spec()` function correctly loaded and parsed the `github_compare_spec.json` file.

### Notes for the reviewer:
Please pay attention to the changes made in `auto_pr_writer.py` and the newly added `github_compare_spec.json` file. Ensure that the new functionality aligns with the expected behavior and that all tests are passing.

Remember to consider any potential security implications of loading JSON files locally and verify that the `load_github_compare_service_spec()` function is handling sensitive data properly.</s>