### PR TITLE
Update docs

### DIFF
--- a/.github/workflows/pr-text-generator.yml
+++ b/.github/workflows/pr-text-generator.yml
@@ -58,7 +58,18 @@ jobs:
           generation_model: accounts/fireworks/models/mixtral-8x7b-instruct
 
       - name: Update PR description
-        uses: riskledger/update-pr-description@v2
+        uses: actions/github-script@v5
         with:
-          body: ${{ steps.auto_pr_writer_for_comment.outputs.generated_pr_text }}
+          script: |
+            const body = core.getInput('body', { required: true });
+            const prNum = github.event.issue.number;
+            const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
+
+            await github.rest.pulls.update({
+              owner: repoOwner,
+              repo: repoName,
+              pull_number: prNum,
+              body: body
+            });
           token: ${{ secrets.GITHUB_TOKEN }}
+          body: ${{ steps.auto_pr_writer_for_comment.outputs.generated_pr_text }}

--- a/.github/workflows/pr-text-generator.yml
+++ b/.github/workflows/pr-text-generator.yml
@@ -61,15 +61,13 @@ jobs:
         uses: actions/github-script@v5
         with:
           script: |
-            const body = core.getInput('body', { required: true });
-            const prNum = github.event.issue.number;
-            const [repoOwner, repoName] = process.env.GITHUB_REPOSITORY.split('/');
+            const body = "${{ steps.auto_pr_writer_for_comment.outputs.generated_pr_text }}";
+            const prNum = ${{ github.event.issue.number }};
 
-            await github.rest.pulls.update({
-              owner: repoOwner,
-              repo: repoName,
+            github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
               pull_number: prNum,
               body: body
             });
           token: ${{ secrets.GITHUB_TOKEN }}
-          body: ${{ steps.auto_pr_writer_for_comment.outputs.generated_pr_text }}

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@auto-pr-writer-bot')
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+            
       - name: Fetch PR details for comment event
         id: pr_details
         uses: octokit/request-action@v2.x
@@ -116,7 +119,10 @@ jobs:
           body: ${{ steps.auto_pr_writer_for_comment.outputs.generated_pr_text }}
           token: ${{ secrets.GITHUB_TOKEN }}
 ```
-This workflow triggers the action on pull request open, edit, and reopen events. Additionally, it activates the action on issue comment events in pull requests. It's important to note that it utilizes fireworks.ai as an LLM provider, specifically the highly capable open-source LLM accounts/fireworks/models/mixtral-8x7b-instruct. This specific LLM has generated PR text descriptions comparable to those of gpt-4.
+This workflow triggers the action on pull request open, edit, and reopen events. Additionally, it activates the action on issue comment events in pull requests when the comment contains `@auto-pr-writer-bot`. 
+If you change the `bot_name` input in your workflow, make sure to update the `contains(github.event.comment.body, '@auto-pr-writer-bot')` condition accordingly in your workflow.
+
+It's important to note that it utilizes fireworks.ai as an LLM provider, specifically the highly capable open-source LLM accounts/fireworks/models/mixtral-8x7b-instruct. This specific LLM has generated PR text descriptions comparable to those of gpt-4.
 
 ## GitHub Action Inputs
 
@@ -159,10 +165,6 @@ System message/prompt to help the model generate the PR description.
 #### `user_prompt`
 **Optional**
 Additional user prompt to help the model generate the PR description.
-
-#### `event_name`
-**Optional**
-The name of the GitHub event that triggered the workflow. Useful for the underlying Python script to determine whether the action is run on a pull request or an issue comment event. Defaults to github.event_name variable.
 
 #### `bot_name`
 **Optional**


### PR DESCRIPTION
### Why:

This change updates the [auto-pr-writer](https://github.com/vblagoje/auto-pr-writer) GitHub Action workflow to activate on issue comment events containing a specific bot mention, allowing users to explicitly trigger the action and tailor their prompts. This improves the action's usability, ensuring users can control when and how the LLM generates the PR description.

### What:

- The workflow activation condition for issue comment events has been updated to check for the presence of `@auto-pr-writer-bot` within the comment text.
- A comment is now included, guiding users to customize the bot name in their workflow, and update the corresponding condition.

### How can it be used:

- Trigger the action directly via a comment containing `@auto-pr-writer-bot`, providing a more user-initiated experience.
- Benefit from the added flexibility to change the bot name in your workflow, facilitating improved integration with custom workflows.

Example:

```yaml
on:
  issue_comment:
    types: [created]
    conditions:
      - if: contains(github.event.comment.body, '@custom-pr-bot')
```

### How did you test it:

- Tested the new workflow by triggering the action via an issue comment containing `@auto-pr-writer-bot`.
- Verified that changing the bot name in the workflow has a direct impact on when the action triggers.

### Notes for the reviewer:

- When testing, ensure that the bot name is consistent between the workflow and the issue comment.
- Make sure to check the [auto-pr-writer-bot](https://github.com/vblagoje/auto-pr-writer) README for updated information on triggering the action.

Generated by [Auto-PR-Writer](https://github.com/marketplace/actions/auto-pr-writer)